### PR TITLE
Bump httpclient from 4.5.6 to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
+            <version>4.5.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumps httpclient from 4.5.6 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:development
...

Signed-off-by: dependabot[bot] <support@github.com>